### PR TITLE
Auto cadastro 241002

### DIFF
--- a/html/socio/cadastro_socio.php
+++ b/html/socio/cadastro_socio.php
@@ -76,16 +76,21 @@ ini_set('display_startup_erros', 0);
             display: none;
         }
 
-        span.obrigatorio{
+        span.obrigatorio {
             color: red;
         }
 
-        .btn-voltar{
+        .btn-voltar {
             font-size: .9rem;
         }
 
-        .btn-voltar:hover{
+        .btn-voltar:hover {
             font-size: 1rem;
+        }
+
+        button:disabled {
+            opacity: 0.5;
+            cursor: not-allowed;
         }
     </style>
 </head>

--- a/html/socio/cadastro_socio.php
+++ b/html/socio/cadastro_socio.php
@@ -296,7 +296,6 @@ ini_set('display_startup_erros', 0);
 
                 <div id="pag6" class="wrap-input100 hidden">
 
-                    <h3 class="text-center">Obrigado por apoiar nossa Instituição!</h3>
                     <div class="container-contact100-form-btn">
                         <button class="contact100-form-btn" id="avanca-terminar">
                             Inscrever-se como sócio apoiador.

--- a/html/socio/js/cadastro_socio.js
+++ b/html/socio/js/cadastro_socio.js
@@ -193,7 +193,7 @@ formCadastro.addEventListener('submit', (ev) => {
             } else {
                 mensagemDiv.innerHTML = `<div class="alert alert-success text-center" role="alert">` +
                     `${data.retorno}`
-                    + `</div>`;
+                    + `</div>` + `<h3 class="text-center">Obrigado por apoiar nossa Instituição!</h3>`;
 
                 const btnVoltar = document.getElementById('volta-endereco');
                 btnVoltar.classList.add('hidden');

--- a/html/socio/js/cadastro_socio.js
+++ b/html/socio/js/cadastro_socio.js
@@ -62,6 +62,11 @@ btnAvancaCpf.addEventListener('click', (ev) => {
                     mensagemDiv.innerHTML = '';
                 } else {
                     acao.value = "atualizar";
+
+                    //Alteração do texto do botão de submite
+                    const botaoEnvio = document.getElementById('avanca-terminar');
+                    botaoEnvio.textContent = 'Atualizar dados';
+
                     //Preenchimento automático dos campos 
 
                     //informações da pag3
@@ -169,7 +174,7 @@ formCadastro.addEventListener('submit', (ev) => {
     const formData = new FormData(formCadastro);
 
     // Desabilita o botão de envio
-    const botaoEnvio = ev.submitter;
+    const botaoEnvio = document.getElementById('avanca-terminar');
     botaoEnvio.disabled = true;
 
     // Realiza a requisição com o fetch
@@ -183,23 +188,25 @@ formCadastro.addEventListener('submit', (ev) => {
                 mensagemDiv.innerHTML = `<div class="alert alert-danger text-center" role="alert">` +
                     `${data.erro}`
                     + `</div>`;
+                botaoEnvio.disabled = false;
                 return;
             } else {
                 mensagemDiv.innerHTML = `<div class="alert alert-success text-center" role="alert">` +
                     `${data.retorno}`
                     + `</div>`;
+
+                const btnVoltar = document.getElementById('volta-endereco');
+                btnVoltar.classList.add('hidden');
             }
         })
         .catch(error => {
             mensagemDiv.innerHTML = `<div class="alert alert-danger text-center" role="alert">` +
                 `Ocorreu um erro ao realizar o cadastro.`
                 + `</div>`;
+            console.error(error);
+            botaoEnvio.disabled = false;
             return;
         })
-        .finally(() => {
-            // Reabilita o botão de envio após a resposta
-            botaoEnvio.disabled = false;
-        });
 });
 
 //Definição do comportamento de voltar

--- a/html/socio/sistema/processa_socio.php
+++ b/html/socio/sistema/processa_socio.php
@@ -168,8 +168,19 @@ function atualizar()
 
         //atualizar os dados de socio
 
-        $tagSolicitante = $pdo->query("SELECT * FROM socio_tag WHERE tag='Solicitante'")->fetch(PDO::FETCH_ASSOC);
-        $idSocioTag = $tagSolicitante['id_sociotag']; //Define o grupo do sócio como Solicitante
+        //verificar se possuí o status de Ativo
+        $sqlBuscaAtivo = "SELECT s.id_sociotag FROM socio s JOIN pessoa p ON (s.id_pessoa=p.id_pessoa) WHERE cpf=:cpf AND s.id_sociostatus =0";
+
+        $stmtStatusAtivo = $pdo->prepare($sqlBuscaAtivo);
+        $stmtStatusAtivo->bindParam(':cpf', $dados['cpf']);
+        $stmtStatusAtivo->execute();
+
+        if ($stmtStatusAtivo->rowCount() > 0) {
+            $idSocioTag = $stmtStatusAtivo->fetch(PDO::FETCH_ASSOC)['id_sociotag'];
+        } else {
+            $tagSolicitante = $pdo->query("SELECT * FROM socio_tag WHERE tag='Solicitante'")->fetch(PDO::FETCH_ASSOC);
+            $idSocioTag = $tagSolicitante['id_sociotag']; //Define o grupo do sócio como Solicitante
+        }
 
         $sqlAtualizarSocio =
             'UPDATE socio s 

--- a/html/socio/sistema/processa_socio.php
+++ b/html/socio/sistema/processa_socio.php
@@ -167,6 +167,10 @@ function atualizar()
         $stmtPessoa->execute();
 
         //atualizar os dados de socio
+
+        $tagSolicitante = $pdo->query("SELECT * FROM socio_tag WHERE tag='Solicitante'")->fetch(PDO::FETCH_ASSOC);
+        $idSocioTag = $tagSolicitante['id_sociotag']; //Define o grupo do sócio como Solicitante
+
         $sqlAtualizarSocio =
             'UPDATE socio s 
         JOIN pessoa p ON s.id_pessoa = p.id_pessoa
@@ -174,7 +178,8 @@ function atualizar()
             s.email = :email, 
             s.valor_periodo = :valor, 
             s.data_referencia = :dataReferencia, 
-            s.id_sociotipo =:periodicidade
+            s.id_sociotipo =:periodicidade, 
+            s.id_sociotag =:tag
         WHERE p.cpf = :cpf';
 
         $dataAtual = new DateTime();
@@ -200,6 +205,7 @@ function atualizar()
         $stmtSocio->bindParam(':dataReferencia', $dataReferencia);
         $stmtSocio->bindParam(':cpf', $dados['cpf']);
         $stmtSocio->bindParam(':periodicidade', $dados['periodicidade']);
+        $stmtSocio->bindParam(':tag', $idSocioTag);
 
         if ($stmtSocio->execute()) {
             $pdo->commit();


### PR DESCRIPTION
Alterado o comportamento da função de atualizar um sócio, mudança na exibição da mensagem de feedback e ocultação do botão de voltar após o cadastro/atualizar ser concluída com sucesso, botão de enviar o formulário muda o seu texto interno dependendo do tipo da operação (cadastrar ou atualizar).

Tag `Solicitante` será atribuída para novos sócios e sócios existentes no sistema cujo status seja diferente de `Ativo`.